### PR TITLE
Fix: Next.js 16 ssr detection

### DIFF
--- a/src/Detection/Rendering/SSR.php
+++ b/src/Detection/Rendering/SSR.php
@@ -7,7 +7,7 @@ use Utopia\Detector\Detection\Rendering;
 class SSR extends Rendering
 {
     private const FRAMEWORK_FILES = [
-        'nextjs' => ['.next/server/pages/_app.js'],
+        'nextjs' => ['.next/server/webpack-runtime.js', '.next/turbopack'],
         'nuxt' => ['server/index.mjs'],
         'sveltekit' => ['handler.js'],
         'astro' => ['server/entry.mjs'],

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -352,8 +352,9 @@ class DetectorTest extends TestCase
     public function renderingDataProvider(): array
     {
         return [
-            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/pages/_app.js'], 'nextjs', 'static', null],
-            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/turbopack'], 'nextjs', 'ssr', null],
+            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/unrelated-file.js'], 'nextjs', 'static', 'server/pages/index.html'],
+            [['server/pages/api/users.js', '.next/server/pages/_app.js'], 'nextjs', 'static', null],
+            [['server/pages/index.html', 'server/pages/api/users.js', '.next/turbopack'], 'nextjs', 'ssr', null],
             [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/webpack-runtime.js'], 'nextjs', 'ssr', null],
             [['index.html', 'about.html', '404.html'], 'nextjs', 'static', null],
             [['nitro.json', 'server/index.mjs'], 'nuxt', 'ssr', null],

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -352,7 +352,9 @@ class DetectorTest extends TestCase
     public function renderingDataProvider(): array
     {
         return [
-            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/pages/_app.js'], 'nextjs', 'ssr', null],
+            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/pages/_app.js'], 'nextjs', 'static', null],
+            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/turbopack'], 'nextjs', 'ssr', null],
+            [['server/pages/index.html', 'server/pages/api/users.js', '.next/server/webpack-runtime.js'], 'nextjs', 'ssr', null],
             [['index.html', 'about.html', '404.html'], 'nextjs', 'static', null],
             [['nitro.json', 'server/index.mjs'], 'nuxt', 'ssr', null],
             [['server/server.mjs'], 'angular', 'ssr', null],


### PR DESCRIPTION
In next.js 16 they removed _app.js we used to use for detection.

I now use same files as in Open Runtimes: https://github.com/open-runtimes/open-runtimes/blob/e9d2ba04ebc1c414acb551355cbeff904f0c326b/runtimes/node/versions/latest/helpers/next-js/bundle.sh#L10-L11

If this breaks in future, I will involve Next.js team to help us find futureproof solution. But this should be good and solid for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy for Next.js SSR builds by updating identification logic to better recognize turbopack and webpack runtime layouts.
* **Tests**
  * Expanded unit test coverage with additional Next.js scenarios to validate static and SSR detection across more file-set combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->