### PR TITLE
feat: Default to PNPM for Node detection and build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $packagerName = $detectedPackager->getName();
 $detector = new Runtime(
     $files,
     new Strategy(Strategy::FILEMATCH), // similar for LANGUAGES and EXTENSIONS
-    'npm'
+    'pnpm'
 );
 
 $detector
@@ -62,7 +62,7 @@ $runtimeCommands = $detectedRuntime->getCommands();
 
 // Initialise Framework Detection
 $files = ['src', 'types', 'makefile', 'components.js', 'debug.js', 'package.json', 'svelte.config.js'];
-$packager = 'npm';
+$packager = 'pnpm';
 $detector = new Framework($files, $packager);
 
 $detector

--- a/docs/add-new-adapter.md
+++ b/docs/add-new-adapter.md
@@ -193,12 +193,12 @@ class MyFramework extends Framework
 
     public function getInstallCommand(): string
     {
-        return 'npm install';
+        return 'pnpm install';
     }
 
     public function getBuildCommand(): string
     {
-        return 'npm run build';
+        return 'pnpm run build';
     }
 
     public function getOutputDirectory(): string

--- a/src/Detection/Framework/Analog.php
+++ b/src/Detection/Framework/Analog.php
@@ -30,7 +30,8 @@ class Analog extends Angular
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Analog extends Angular
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Angular.php
+++ b/src/Detection/Framework/Angular.php
@@ -30,7 +30,8 @@ class Angular extends JS
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Angular extends JS
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -48,7 +48,8 @@ class Astro extends JS
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -56,8 +57,9 @@ class Astro extends JS
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Lynx.php
+++ b/src/Detection/Framework/Lynx.php
@@ -30,7 +30,8 @@ class Lynx extends React
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Lynx extends React
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/NextJs.php
+++ b/src/Detection/Framework/NextJs.php
@@ -30,7 +30,8 @@ class NextJs extends React
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class NextJs extends React
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Nuxt.php
+++ b/src/Detection/Framework/Nuxt.php
@@ -30,7 +30,8 @@ class Nuxt extends Vue
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Nuxt extends Vue
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/React.php
+++ b/src/Detection/Framework/React.php
@@ -30,7 +30,8 @@ class React extends JS
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class React extends JS
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/ReactNative.php
+++ b/src/Detection/Framework/ReactNative.php
@@ -30,7 +30,8 @@ class ReactNative extends React
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class ReactNative extends React
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Remix.php
+++ b/src/Detection/Framework/Remix.php
@@ -30,7 +30,8 @@ class Remix extends React
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Remix extends React
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Svelte.php
+++ b/src/Detection/Framework/Svelte.php
@@ -30,7 +30,8 @@ class Svelte extends JS
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Svelte extends JS
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -30,7 +30,8 @@ class SvelteKit extends Svelte
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class SvelteKit extends Svelte
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -30,7 +30,8 @@ class TanStackStart extends React
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class TanStackStart extends React
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Framework/Vue.php
+++ b/src/Detection/Framework/Vue.php
@@ -30,7 +30,8 @@ class Vue extends JS
         return match ($this->packager) {
             'yarn' => 'yarn install',
             'pnpm' => 'pnpm install',
-            default => 'npm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 
@@ -38,8 +39,9 @@ class Vue extends JS
     {
         return match ($this->packager) {
             'yarn' => 'yarn build',
-            'pnpm' => 'pnpm build',
-            default => 'npm run build',
+            'pnpm' => 'pnpm run build',
+            'npm' => 'npm run build',
+            default => 'pnpm run build',
         };
     }
 

--- a/src/Detection/Packager/PNPM.php
+++ b/src/Detection/Packager/PNPM.php
@@ -16,6 +16,12 @@ class PNPM extends Packager
      */
     public function getFiles(): array
     {
-        return ['pnpm-lock.yaml'];
+        return [
+            'package.json',
+            'pnpm-lock.yaml',
+            'package-lock.json',
+            'yarn.lock',
+            'bun.lockb',
+        ];
     }
 }

--- a/src/Detection/Packager/PNPM.php
+++ b/src/Detection/Packager/PNPM.php
@@ -17,11 +17,7 @@ class PNPM extends Packager
     public function getFiles(): array
     {
         return [
-            'package.json',
             'pnpm-lock.yaml',
-            'package-lock.json',
-            'yarn.lock',
-            'bun.lockb',
         ];
     }
 }

--- a/src/Detection/Runtime/Node.php
+++ b/src/Detection/Runtime/Node.php
@@ -22,9 +22,10 @@ class Node extends Runtime
     public function getCommands(): string
     {
         return match ($this->packager) {
-            'yarn' => 'yarn install && yarn build',
-            'pnpm' => 'pnpm install && pnpm run build',
-            default => 'npm install && npm run build',
+            'yarn' => 'yarn install',
+            'pnpm' => 'pnpm install',
+            'npm' => 'npm install',
+            default => 'pnpm install',
         };
     }
 

--- a/src/Detector/Framework.php
+++ b/src/Detector/Framework.php
@@ -16,9 +16,9 @@ class Framework extends Detector
      */
     protected array $options = [];
 
-    protected string $packager = 'npm';
+    protected string $packager = 'pnpm';
 
-    public function __construct(string $packager = 'npm')
+    public function __construct(string $packager = 'pnpm')
     {
         parent::__construct();
         $this->packager = $packager;

--- a/src/Detector/Runtime.php
+++ b/src/Detector/Runtime.php
@@ -14,9 +14,9 @@ class Runtime extends Detector
 
     protected Strategy $strategy;
 
-    protected string $packager = 'npm';
+    protected string $packager = 'pnpm';
 
-    public function __construct(Strategy $strategy, string $packager = 'npm')
+    public function __construct(Strategy $strategy, string $packager = 'pnpm')
     {
         parent::__construct();
         $this->strategy = $strategy;

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -72,8 +72,8 @@ class DetectorTest extends TestCase
     public function packagerDataProvider(): array
     {
         return [
-            [['bun.lockb', 'fly.toml', 'package.json', 'remix.config.js'], 'npm'],
-            [['yarn.lock'], 'yarn'],
+            [['bun.lockb', 'fly.toml', 'package.json', 'remix.config.js'], 'pnpm'],
+            [['yarn.lock'], 'pnpm'],
             [['pnpm-lock.yaml'], 'pnpm'],
             [['composer.json'], null],  // test for FAILURE
         ];
@@ -88,7 +88,7 @@ class DetectorTest extends TestCase
         ?string $runtime,
         ?string $commands,
         ?string $entrypoint,
-        string $packager = 'npm'
+        string $packager = 'pnpm'
     ): void {
         $detector = new Runtime(
             new Strategy(Strategy::FILEMATCH),
@@ -130,12 +130,12 @@ class DetectorTest extends TestCase
     public function runtimeDataProviderByFilematch(): array
     {
         return [
-            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'npm install && npm run build', 'index.js', 'npm'],
+            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'pnpm install && pnpm run build', 'index.js', 'pnpm'],
             [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'yarn install && yarn build', 'index.js', 'yarn'],
-            [['composer.json', 'composer.lock'], 'php', 'composer install && composer run build', 'index.php', 'npm'],
-            [['pubspec.yaml'], 'dart', 'dart pub get', 'main.dart', 'npm'],
-            [['Gemfile', 'Gemfile.lock'], 'ruby', 'bundle install && bundle exec rake build', 'main.rb', 'npm'],
-            [['index.html', 'style.css'], null, null, null, 'npm'], // Test for FAILURE
+            [['composer.json', 'composer.lock'], 'php', 'composer install && composer run build', 'index.php', 'pnpm'],
+            [['pubspec.yaml'], 'dart', 'dart pub get', 'main.dart', 'pnpm'],
+            [['Gemfile', 'Gemfile.lock'], 'ruby', 'bundle install && bundle exec rake build', 'main.rb', 'pnpm'],
+            [['index.html', 'style.css'], null, null, null, 'pnpm'], // Test for FAILURE
         ];
     }
 
@@ -147,7 +147,7 @@ class DetectorTest extends TestCase
         array $files,
         ?string $runtime,
         ?string $commands,
-        string $packager = 'npm'
+        string $packager = 'pnpm'
     ): void {
         $detector = new Runtime(
             new Strategy(Strategy::LANGUAGES),
@@ -191,8 +191,8 @@ class DetectorTest extends TestCase
             [
                 ['TypeScript', 'JavaScript', 'DockerFile'],
                 'node',
-                'npm install && npm run build',
-                'npm',
+                'pnpm install && pnpm run build',
+                'pnpm',
             ],
             [
                 ['TypeScript', 'JavaScript', 'DockerFile'],
@@ -205,7 +205,7 @@ class DetectorTest extends TestCase
                 ['HTML'],
                 null,
                 null,
-                'npm',
+                'pnpm',
             ],
         ];
     }
@@ -218,7 +218,7 @@ class DetectorTest extends TestCase
         array $files,
         ?string $runtime,
         ?string $commands,
-        string $packager = 'npm'
+        string $packager = 'pnpm'
     ): void {
         $detector = new Runtime(
             new Strategy(Strategy::EXTENSION),
@@ -259,7 +259,7 @@ class DetectorTest extends TestCase
     public function runtimeDataProviderByFileExtensions(): array
     {
         return [
-            [['main.ts', 'main.js', 'DockerFile'], 'node', 'npm install && npm run build'],
+            [['main.ts', 'main.js', 'DockerFile'], 'node', 'pnpm install && pnpm run build'],
             [['main.ts', 'main.js', 'DockerFile'], 'node', 'yarn install && yarn build', 'yarn'],
             [['composer.json', 'index.php', 'DockerFile'], 'php', 'composer install && composer run build'],
             [['index.html', 'style.css'], null, null], // Test for FAILURE
@@ -270,7 +270,7 @@ class DetectorTest extends TestCase
      * @param string[] $files List of files to check
      * @dataProvider frameworkDataProvider
      */
-    public function testFrameworkDetection(array $files, ?string $framework, ?string $installCommand = null, ?string $buildCommand = null, ?string $outputDirectory = null, string $packager = 'npm'): void
+    public function testFrameworkDetection(array $files, ?string $framework, ?string $installCommand = null, ?string $buildCommand = null, ?string $outputDirectory = null, string $packager = 'pnpm'): void
     {
         $detector = new Framework($packager);
 
@@ -309,14 +309,14 @@ class DetectorTest extends TestCase
     public function frameworkDataProvider(): array
     {
         return [
-            [['src', 'types', 'makefile', 'components.js', 'debug.js', 'package.json', 'svelte.config.js'], 'sveltekit', 'npm install', 'npm run build', './build'],
-            [['app', 'backend', 'public', 'Dockerfile', 'docker-compose.yml', 'ecosystem.config.js', 'middleware.ts', 'next.config.js', 'package-lock.json', 'package.json', 'server.js', 'tsconfig.json'], 'nextjs', 'npm install', 'npm run build', './.next'],
-            [['assets', 'components', 'layouts', 'pages', 'babel.config.js', 'error.vue', 'nuxt.config.js', 'yarn.lock'], 'nuxt', 'npm install', 'npm run build', './output'],
-            [['lynx.config.js'], 'lynx', 'npm install', 'npm run build', './dist'],
-            [['src', 'package.json', 'tsconfig.json', 'angular.json', 'logo.png'], 'angular', 'npm install', 'npm run build', './dist/angular'],
-            [['app', 'public', 'remix.config.js', 'remix.env.d.ts', 'sandbox.config.js', 'tsconfig.json', 'package.json'], 'remix', 'npm install', 'npm run build', './build'],
-            [['public', 'src', 'astro.config.mjs', 'package-lock.json', 'package.json', 'tsconfig.json'], 'astro', 'npm install', 'npm run build', './dist'],
-            [['src', 'static', 'scripts', 'eslint.config.js', 'package.json', 'pnpm-lock.yaml', 'svelte.config.js', 'tsconfig.js', 'vite.config.js', 'vite.config.lib.js'], 'sveltekit', 'npm install', 'npm run build', './build'],
+            [['src', 'types', 'makefile', 'components.js', 'debug.js', 'package.json', 'svelte.config.js'], 'sveltekit', 'pnpm install', 'pnpm run build', './build'],
+            [['app', 'backend', 'public', 'Dockerfile', 'docker-compose.yml', 'ecosystem.config.js', 'middleware.ts', 'next.config.js', 'package-lock.json', 'package.json', 'server.js', 'tsconfig.json'], 'nextjs', 'pnpm install', 'pnpm run build', './.next'],
+            [['assets', 'components', 'layouts', 'pages', 'babel.config.js', 'error.vue', 'nuxt.config.js', 'yarn.lock'], 'nuxt', 'pnpm install', 'pnpm run build', './output'],
+            [['lynx.config.js'], 'lynx', 'pnpm install', 'pnpm run build', './dist'],
+            [['src', 'package.json', 'tsconfig.json', 'angular.json', 'logo.png'], 'angular', 'pnpm install', 'pnpm run build', './dist/angular'],
+            [['app', 'public', 'remix.config.js', 'remix.env.d.ts', 'sandbox.config.js', 'tsconfig.json', 'package.json'], 'remix', 'pnpm install', 'pnpm run build', './build'],
+            [['public', 'src', 'astro.config.mjs', 'package-lock.json', 'package.json', 'tsconfig.json'], 'astro', 'pnpm install', 'pnpm run build', './dist'],
+            [['src', 'static', 'scripts', 'eslint.config.js', 'package.json', 'pnpm-lock.yaml', 'svelte.config.js', 'tsconfig.js', 'vite.config.js', 'vite.config.lib.js'], 'sveltekit', 'pnpm install', 'pnpm run build', './build'],
             [['index.html', 'style.css'], null, null, null, null], // Test for FAILURE
         ];
     }
@@ -452,7 +452,7 @@ class DetectorTest extends TestCase
 
         $this->assertSame('tanstack-start', $detectedFramework->getName());
         $this->assertSame('pnpm install', $detectedFramework->getInstallCommand());
-        $this->assertSame('pnpm build', $detectedFramework->getBuildCommand());
+        $this->assertSame('pnpm run build', $detectedFramework->getBuildCommand());
     }
 
     /**

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -72,8 +72,8 @@ class DetectorTest extends TestCase
     public function packagerDataProvider(): array
     {
         return [
-            [['bun.lockb', 'fly.toml', 'package.json', 'remix.config.js'], 'pnpm'],
-            [['yarn.lock'], 'pnpm'],
+            [['bun.lockb', 'fly.toml', 'package.json', 'remix.config.js'], 'npm'],
+            [['yarn.lock'], 'yarn'],
             [['pnpm-lock.yaml'], 'pnpm'],
             [['composer.json'], null],  // test for FAILURE
         ];

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -130,8 +130,8 @@ class DetectorTest extends TestCase
     public function runtimeDataProviderByFilematch(): array
     {
         return [
-            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'pnpm install && pnpm run build', 'index.js', 'pnpm'],
-            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'yarn install && yarn build', 'index.js', 'yarn'],
+            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'pnpm install', 'index.js', 'pnpm'],
+            [['package-lock.json', 'yarn.lock', 'tsconfig.json'], 'node', 'yarn install', 'index.js', 'yarn'],
             [['composer.json', 'composer.lock'], 'php', 'composer install && composer run build', 'index.php', 'pnpm'],
             [['pubspec.yaml'], 'dart', 'dart pub get', 'main.dart', 'pnpm'],
             [['Gemfile', 'Gemfile.lock'], 'ruby', 'bundle install && bundle exec rake build', 'main.rb', 'pnpm'],
@@ -191,13 +191,13 @@ class DetectorTest extends TestCase
             [
                 ['TypeScript', 'JavaScript', 'DockerFile'],
                 'node',
-                'pnpm install && pnpm run build',
+                'pnpm install',
                 'pnpm',
             ],
             [
                 ['TypeScript', 'JavaScript', 'DockerFile'],
                 'node',
-                'yarn install && yarn build',
+                'yarn install',
                 'yarn',
             ],
             // Test for FAILURE
@@ -259,8 +259,8 @@ class DetectorTest extends TestCase
     public function runtimeDataProviderByFileExtensions(): array
     {
         return [
-            [['main.ts', 'main.js', 'DockerFile'], 'node', 'pnpm install && pnpm run build'],
-            [['main.ts', 'main.js', 'DockerFile'], 'node', 'yarn install && yarn build', 'yarn'],
+            [['main.ts', 'main.js', 'DockerFile'], 'node', 'pnpm install'],
+            [['main.ts', 'main.js', 'DockerFile'], 'node', 'yarn install', 'yarn'],
             [['composer.json', 'index.php', 'DockerFile'], 'php', 'composer install && composer run build'],
             [['index.html', 'style.css'], null, null], // Test for FAILURE
         ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default package manager changed from npm to pnpm; install/build suggestions now prefer pnpm by default.
  * Runtime outputs now provide install commands separately (install and build no longer combined).

* **Documentation**
  * Examples and guides updated to use pnpm for install/build commands and snippets.

* **Tests**
  * Test defaults and expectations updated to reflect pnpm as the default packager and adjusted command expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->