### PR TITLE
feat: add adapter detection via config file content

### DIFF
--- a/src/Detection/Framework.php
+++ b/src/Detection/Framework.php
@@ -39,4 +39,21 @@ abstract class Framework extends Detection
     abstract public function getBuildCommand(): string;
 
     abstract public function getOutputDirectory(): string;
+
+    /**
+     * @return array<string> Config files to read for adapter detection, in priority order.
+     */
+    public function getConfigFiles(): array
+    {
+        return [];
+    }
+
+    /**
+     * Detect the adapter ('ssr' or 'static') from config file content.
+     * Returns empty string if detection is not possible.
+     */
+    public function getAdapter(string $configContent): string
+    {
+        return '';
+    }
 }

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -78,7 +78,7 @@ class Astro extends JS
 
     public function getAdapter(string $configContent): string
     {
-        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+        $stripped = \preg_replace('/(?<!:)\/\/[^\n]*/', '', $configContent) ?? $configContent;
 
         if (\preg_match('/\boutput\s*:\s*[\x27\x22](?:server|hybrid)[\x27\x22]/', $stripped)) {
             return 'ssr';

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -67,4 +67,22 @@ class Astro extends JS
     {
         return './dist';
     }
+
+    public function getConfigFiles(): array
+    {
+        return ['astro.config.mjs', 'astro.config.js', 'astro.config.ts'];
+    }
+
+    public function getAdapter(string $configContent): string
+    {
+        // 'server' and 'hybrid' both require the SSR adapter
+        if (\str_contains($configContent, "output: 'server'") || \str_contains($configContent, 'output: "server"')) {
+            return 'ssr';
+        }
+        if (\str_contains($configContent, "output: 'hybrid'") || \str_contains($configContent, 'output: "hybrid"')) {
+            return 'ssr';
+        }
+
+        return 'static';
+    }
 }

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -80,7 +80,7 @@ class Astro extends JS
     {
         $stripped = \preg_replace('/(?<!:)\/\/[^\n]*/', '', $configContent) ?? $configContent;
 
-        if (\preg_match('/\boutput\s*:\s*[\x27\x22](?:server|hybrid)[\x27\x22]/', $stripped)) {
+        if (\preg_match('/\boutput\s*:\s*[\x27\x22\x60](?:server|hybrid)[\x27\x22\x60]/', $stripped)) {
             return 'ssr';
         }
 

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -78,10 +78,9 @@ class Astro extends JS
 
     public function getAdapter(string $configContent): string
     {
-        if (\str_contains($configContent, "output: 'server'") || \str_contains($configContent, 'output: "server"')) {
-            return 'ssr';
-        }
-        if (\str_contains($configContent, "output: 'hybrid'") || \str_contains($configContent, 'output: "hybrid"')) {
+        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+
+        if (\preg_match('/\boutput\s*:\s*[\x27\x22](?:server|hybrid)[\x27\x22]/', $stripped)) {
             return 'ssr';
         }
 

--- a/src/Detection/Framework/Astro.php
+++ b/src/Detection/Framework/Astro.php
@@ -68,6 +68,9 @@ class Astro extends JS
         return './dist';
     }
 
+    /**
+     * @return array<string>
+     */
     public function getConfigFiles(): array
     {
         return ['astro.config.mjs', 'astro.config.js', 'astro.config.ts'];
@@ -75,7 +78,6 @@ class Astro extends JS
 
     public function getAdapter(string $configContent): string
     {
-        // 'server' and 'hybrid' both require the SSR adapter
         if (\str_contains($configContent, "output: 'server'") || \str_contains($configContent, 'output: "server"')) {
             return 'ssr';
         }

--- a/src/Detection/Framework/Remix.php
+++ b/src/Detection/Framework/Remix.php
@@ -52,15 +52,6 @@ class Remix extends React
 
     public function getAdapter(string $configContent): string
     {
-        // @remix-run/serve in dependencies indicates SSR; static adapters use build/client output only
-        if (\str_contains($configContent, '"@remix-run/serve"') || \str_contains($configContent, "'@remix-run/serve'")) {
-            return 'ssr';
-        }
-        // Vite-based Remix v2+ with SSR adapters (e.g. @remix-run/express, @remix-run/node)
-        if (\str_contains($configContent, '@remix-run/express') || \str_contains($configContent, '@remix-run/node')) {
-            return 'ssr';
-        }
-
-        return 'ssr'; // Remix defaults to SSR; static mode requires explicit adapter configuration
+        return 'ssr';
     }
 }

--- a/src/Detection/Framework/Remix.php
+++ b/src/Detection/Framework/Remix.php
@@ -49,4 +49,18 @@ class Remix extends React
     {
         return './build';
     }
+
+    public function getAdapter(string $configContent): string
+    {
+        // @remix-run/serve in dependencies indicates SSR; static adapters use build/client output only
+        if (\str_contains($configContent, '"@remix-run/serve"') || \str_contains($configContent, "'@remix-run/serve'")) {
+            return 'ssr';
+        }
+        // Vite-based Remix v2+ with SSR adapters (e.g. @remix-run/express, @remix-run/node)
+        if (\str_contains($configContent, '@remix-run/express') || \str_contains($configContent, '@remix-run/node')) {
+            return 'ssr';
+        }
+
+        return 'ssr'; // Remix defaults to SSR; static mode requires explicit adapter configuration
+    }
 }

--- a/src/Detection/Framework/Remix.php
+++ b/src/Detection/Framework/Remix.php
@@ -50,6 +50,14 @@ class Remix extends React
         return './build';
     }
 
+    /**
+     * @return array<string>
+     */
+    public function getConfigFiles(): array
+    {
+        return ['package.json'];
+    }
+
     public function getAdapter(string $configContent): string
     {
         return 'ssr';

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -60,6 +60,8 @@ class SvelteKit extends Svelte
 
     public function getAdapter(string $configContent): string
     {
-        return \str_contains($configContent, '@sveltejs/adapter-static') ? 'static' : 'ssr';
+        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+
+        return \str_contains($stripped, '@sveltejs/adapter-static') ? 'static' : 'ssr';
     }
 }

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -55,7 +55,7 @@ class SvelteKit extends Svelte
      */
     public function getConfigFiles(): array
     {
-        return ['svelte.config.js', 'svelte.config.ts', 'package.json'];
+        return ['svelte.config.js', 'svelte.config.mjs', 'svelte.config.ts', 'package.json'];
     }
 
     public function getAdapter(string $configContent): string

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -50,6 +50,9 @@ class SvelteKit extends Svelte
         return './build';
     }
 
+    /**
+     * @return array<string>
+     */
     public function getConfigFiles(): array
     {
         return ['svelte.config.js', 'svelte.config.ts'];
@@ -57,7 +60,6 @@ class SvelteKit extends Svelte
 
     public function getAdapter(string $configContent): string
     {
-        // Detect static adapter from package.json dependencies or svelte.config content
         return \str_contains($configContent, '@sveltejs/adapter-static') ? 'static' : 'ssr';
     }
 }

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -49,4 +49,15 @@ class SvelteKit extends Svelte
     {
         return './build';
     }
+
+    public function getConfigFiles(): array
+    {
+        return ['svelte.config.js', 'svelte.config.ts'];
+    }
+
+    public function getAdapter(string $configContent): string
+    {
+        // Detect static adapter from package.json dependencies or svelte.config content
+        return \str_contains($configContent, '@sveltejs/adapter-static') ? 'static' : 'ssr';
+    }
 }

--- a/src/Detection/Framework/SvelteKit.php
+++ b/src/Detection/Framework/SvelteKit.php
@@ -55,12 +55,12 @@ class SvelteKit extends Svelte
      */
     public function getConfigFiles(): array
     {
-        return ['svelte.config.js', 'svelte.config.ts'];
+        return ['svelte.config.js', 'svelte.config.ts', 'package.json'];
     }
 
     public function getAdapter(string $configContent): string
     {
-        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+        $stripped = \preg_replace('/(?<!:)\/\/[^\n]*/', '', $configContent) ?? $configContent;
 
         return \str_contains($stripped, '@sveltejs/adapter-static') ? 'static' : 'ssr';
     }

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -50,6 +50,9 @@ class TanStackStart extends React
         return './.output';
     }
 
+    /**
+     * @return array<string>
+     */
     public function getConfigFiles(): array
     {
         return ['vite.config.ts', 'vite.config.js', 'vite.config.mjs'];

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -60,7 +60,7 @@ class TanStackStart extends React
 
     public function getAdapter(string $configContent): string
     {
-        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+        $stripped = \preg_replace('/(?<!:)\/\/[^\n]*/', '', $configContent) ?? $configContent;
 
         if (!\preg_match('/\bprerender\b/', $stripped) || \preg_match('/\bprerender\s*:\s*false\b/', $stripped)) {
             return 'ssr';

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -49,4 +49,14 @@ class TanStackStart extends React
     {
         return './.output';
     }
+
+    public function getConfigFiles(): array
+    {
+        return ['vite.config.ts', 'vite.config.js', 'vite.config.mjs'];
+    }
+
+    public function getAdapter(string $configContent): string
+    {
+        return \str_contains($configContent, 'prerender') ? 'static' : 'ssr';
+    }
 }

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -62,7 +62,7 @@ class TanStackStart extends React
     {
         $stripped = \preg_replace('/(?<!:)\/\/[^\n]*/', '', $configContent) ?? $configContent;
 
-        if (!\preg_match('/\bprerender\b/', $stripped) || \preg_match('/\bprerender\s*:\s*false\b/', $stripped)) {
+        if (!\preg_match('/\bprerender\b/', $stripped) || \preg_match('/\bprerender[\x27\x22]?\s*:\s*false\b/', $stripped)) {
             return 'ssr';
         }
 

--- a/src/Detection/Framework/TanStackStart.php
+++ b/src/Detection/Framework/TanStackStart.php
@@ -60,6 +60,12 @@ class TanStackStart extends React
 
     public function getAdapter(string $configContent): string
     {
-        return \str_contains($configContent, 'prerender') ? 'static' : 'ssr';
+        $stripped = \preg_replace('/\/\/[^\n]*/', '', $configContent) ?? $configContent;
+
+        if (!\preg_match('/\bprerender\b/', $stripped) || \preg_match('/\bprerender\s*:\s*false\b/', $stripped)) {
+            return 'ssr';
+        }
+
+        return 'static';
     }
 }

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -798,4 +798,43 @@ class DetectorTest extends TestCase
 
         $this->assertSame($framework, $detection->getName(), $assertion);
     }
+
+    public function testTanStackStartAdapterDetection(): void
+    {
+        $fw = new TanStackStart();
+
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart()] })'));
+        $this->assertSame('static', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: { routes: [\'/\'] } })] })'));
+        $this->assertNotEmpty($fw->getConfigFiles());
+    }
+
+    public function testSvelteKitAdapterDetection(): void
+    {
+        $fw = new SvelteKit();
+
+        $this->assertSame('ssr', $fw->getAdapter('import adapter from \'@sveltejs/adapter-auto\'; export default { kit: { adapter: adapter() } }'));
+        $this->assertSame('static', $fw->getAdapter('import adapter from \'@sveltejs/adapter-static\'; export default { kit: { adapter: adapter() } }'));
+        $this->assertSame('static', $fw->getAdapter('{"dependencies":{"@sveltejs/adapter-static":"^3.0.0"}}'));
+        $this->assertNotEmpty($fw->getConfigFiles());
+    }
+
+    public function testAstroAdapterDetection(): void
+    {
+        $fw = new Astro();
+
+        $this->assertSame('static', $fw->getAdapter('export default defineConfig({ integrations: [] })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: \'server\', adapter: node({ mode: \'standalone\' }) })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: "server" })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: \'hybrid\' })'));
+        $this->assertNotEmpty($fw->getConfigFiles());
+    }
+
+    public function testRemixAdapterDetection(): void
+    {
+        $fw = new Remix();
+
+        $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/react":"^2.0.0"}}'));
+        $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/serve":"^2.0.0"}}'));
+        $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/node":"^2.0.0"}}'));
+    }
 }

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -834,6 +834,8 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output  :  \'server\' })'));
         $this->assertSame('static', $fw->getAdapter('// output: \'server\'' . "\n" . 'export default defineConfig({})'));
         $this->assertSame('ssr', $fw->getAdapter('site: "https://example.com",' . "\n" . 'output: "server"'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: `server` })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: `hybrid` })'));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -806,6 +806,7 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart()] })'));
         $this->assertSame('static', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: { routes: [\'/\'] } })] })'));
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: false })] })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ "prerender": false })] })'));
         $this->assertSame('ssr', $fw->getAdapter('// prerender: true' . "\n" . 'export default defineConfig({})'));
         $this->assertSame('static', $fw->getAdapter('server: { url: "https://example.com" },' . "\n" . 'prerender: { routes: [\'/\'] }'));
         $this->assertNotEmpty($fw->getConfigFiles());

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -807,6 +807,7 @@ class DetectorTest extends TestCase
         $this->assertSame('static', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: { routes: [\'/\'] } })] })'));
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: false })] })'));
         $this->assertSame('ssr', $fw->getAdapter('// prerender: true' . "\n" . 'export default defineConfig({})'));
+        $this->assertSame('static', $fw->getAdapter('server: { url: "https://example.com" },' . "\n" . 'prerender: { routes: [\'/\'] }'));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -818,6 +819,7 @@ class DetectorTest extends TestCase
         $this->assertSame('static', $fw->getAdapter('import adapter from \'@sveltejs/adapter-static\'; export default { kit: { adapter: adapter() } }'));
         $this->assertSame('static', $fw->getAdapter('{"dependencies":{"@sveltejs/adapter-static":"^3.0.0"}}'));
         $this->assertSame('ssr', $fw->getAdapter('// import adapter from \'@sveltejs/adapter-static\'' . "\n" . 'import adapter from \'@sveltejs/adapter-auto\''));
+        $this->assertContains('package.json', $fw->getConfigFiles());
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -831,6 +833,7 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: \'hybrid\' })'));
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output  :  \'server\' })'));
         $this->assertSame('static', $fw->getAdapter('// output: \'server\'' . "\n" . 'export default defineConfig({})'));
+        $this->assertSame('ssr', $fw->getAdapter('site: "https://example.com",' . "\n" . 'output: "server"'));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -842,5 +845,6 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/serve":"^2.0.0"}}'));
         $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/node":"^2.0.0"}}'));
         $this->assertSame('ssr', $fw->getAdapter(''));
+        $this->assertContains('package.json', $fw->getConfigFiles());
     }
 }

--- a/tests/unit/DetectorTest.php
+++ b/tests/unit/DetectorTest.php
@@ -805,6 +805,8 @@ class DetectorTest extends TestCase
 
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart()] })'));
         $this->assertSame('static', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: { routes: [\'/\'] } })] })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ plugins: [tanstackStart({ prerender: false })] })'));
+        $this->assertSame('ssr', $fw->getAdapter('// prerender: true' . "\n" . 'export default defineConfig({})'));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -815,6 +817,7 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('import adapter from \'@sveltejs/adapter-auto\'; export default { kit: { adapter: adapter() } }'));
         $this->assertSame('static', $fw->getAdapter('import adapter from \'@sveltejs/adapter-static\'; export default { kit: { adapter: adapter() } }'));
         $this->assertSame('static', $fw->getAdapter('{"dependencies":{"@sveltejs/adapter-static":"^3.0.0"}}'));
+        $this->assertSame('ssr', $fw->getAdapter('// import adapter from \'@sveltejs/adapter-static\'' . "\n" . 'import adapter from \'@sveltejs/adapter-auto\''));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -826,6 +829,8 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: \'server\', adapter: node({ mode: \'standalone\' }) })'));
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: "server" })'));
         $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output: \'hybrid\' })'));
+        $this->assertSame('ssr', $fw->getAdapter('export default defineConfig({ output  :  \'server\' })'));
+        $this->assertSame('static', $fw->getAdapter('// output: \'server\'' . "\n" . 'export default defineConfig({})'));
         $this->assertNotEmpty($fw->getConfigFiles());
     }
 
@@ -836,5 +841,6 @@ class DetectorTest extends TestCase
         $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/react":"^2.0.0"}}'));
         $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/serve":"^2.0.0"}}'));
         $this->assertSame('ssr', $fw->getAdapter('{"dependencies":{"@remix-run/node":"^2.0.0"}}'));
+        $this->assertSame('ssr', $fw->getAdapter(''));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `getConfigFiles()` and `getAdapter()` methods to the `Framework` base class
- Implements adapter detection for dual-adapter frameworks: **TanStack Start**, **SvelteKit**, **Astro**, **Remix**
- Each framework reads its config file and detects whether the project is configured for SSR or static output

## Detection logic

| Framework | Config file(s) | Static signal | Default |
|---|---|---|---|
| TanStack Start | vite.config.ts/js/mjs | `prerender` keyword | ssr |
| SvelteKit | svelte.config.js/ts or package.json | `@sveltejs/adapter-static` | ssr |
| Astro | astro.config.mjs/js/ts | `output: 'server'` or `'hybrid'` | static |
| Remix | package.json | always ssr (static is edge case) | ssr |

## Test plan
- [ ] Verify detection returns correct adapter for SSR and static variants of each framework
- [ ] Verify fallback to empty string works when no config file is present